### PR TITLE
fix: Missing thresholds leading to visualization crashing

### DIFF
--- a/visualizations/status-timeline-widget/status-timeline-widget.js
+++ b/visualizations/status-timeline-widget/status-timeline-widget.js
@@ -60,7 +60,7 @@ export default class StatusWidget extends React.Component {
       height,
       accountId,
       query,
-      thresholds,
+      thresholds = [],
       onClickUrl,
       modalQueries,
       hideMetrics,


### PR DESCRIPTION
**TL;DR:**

With this PR we adapt the visualization to work nicely when embedded in Query Builder.
We're going to provide a default value for thresholds so that the viz keeps working even if none were provided

**Background:**

The recent release of Query Builder included multiple improvements, most importantly, it is now able to edit custom visualizations, as well as validate and sanitize the configuration of the custom visualization. The "Edit" widget action in dashboards no longer takes us to the visualizations builder, but to Query Builder instead, and it imposes some rules described below.

**Query Builder's treatment of the configuration:**

The schema defined in the `nr1.json` file establishes the shape of the configuration supported and understood by the visualization. Because visualizations can be used in many contexts, we can't make any assumptions about the configuration being passed to it - whether all fields will be included, and whether the values will have the right type.

Therefore, it's on the visualization to handle these scenarios gracefully. While in Query Builder the validation layer is going to prevent widgets from being saved with values of incorrect type, we still have to guard against the missing values.

With this PR we adapt the visualization to fail gracefully when embedded in Query Builder.

**Comparison:**

| Before 🔴  | After 🟢  |
|:-:|:-:|
| ![status-timeline-widget-before](https://user-images.githubusercontent.com/90652/170528589-0a07a28b-e727-4995-8c57-8dc1da496219.gif) | ![status-timeline-widget-after](https://user-images.githubusercontent.com/90652/170528571-923829b9-e777-4119-a241-c502f11f2b68.gif) | 